### PR TITLE
Fix date field alignment on mobile browsers (Fixes #1)

### DIFF
--- a/components/ActivityForm.tsx
+++ b/components/ActivityForm.tsx
@@ -146,7 +146,7 @@ export default function ActivityForm({
             value={formData.activity_date}
             onChange={handleChange}
             required
-            className="w-full px-4 py-2.5 bg-warm-50 border-2 border-warm-200 text-warm-900 rounded-xl focus:outline-none focus:ring-2 focus:ring-sage focus:border-sage transition-all duration-200"
+            className="w-full max-w-full px-4 py-2.5 bg-warm-50 border-2 border-warm-200 text-warm-900 rounded-xl focus:outline-none focus:ring-2 focus:ring-sage focus:border-sage transition-all duration-200"
           />
         </div>
 


### PR DESCRIPTION
## Summary
Fixes the date input field overlapping/extending beyond container on mobile browsers.

## Changes
- Added `max-w-full` class to date input to prevent browser-specific width issues
- Date input now properly constrains to its container width on all screen sizes

## Issue
Closes #1

## Testing
- [x] Build succeeds without errors
- [x] Date field renders correctly on mobile viewport
- [x] Field width matches other input fields
- [x] No overflow on narrow screens

## Screenshots
Before: Date field overlapped right edge
After: Date field properly contained within form