### PR TITLE
[v0.7.2] Auto-expand additional details when editing activities

### DIFF
--- a/components/ActivityForm.tsx
+++ b/components/ActivityForm.tsx
@@ -25,7 +25,8 @@ export default function ActivityForm({
   peopleSuggestions = [],
   tagSuggestions = [],
 }: ActivityFormProps) {
-  const [showFullEntry, setShowFullEntry] = useState(false);
+  // v0.7.2 - Auto-expand additional details when editing
+  const [showFullEntry, setShowFullEntry] = useState(!!initialData);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [formData, setFormData] = useState<CreateActivityInput>({


### PR DESCRIPTION
## Summary
Improve the editing experience by automatically expanding the additional details section when editing an activity, eliminating the need to manually click the expand button every time.

### Changes
- **Auto-expand on Edit**: Additional details section automatically expanded when `initialData` exists
- **Collapsed on Create**: New activity form keeps additional details collapsed by default
- **Toggle Still Works**: Users can still manually expand/collapse the section as needed

### Implementation
Simple one-line change to the initial state:
```typescript
const [showFullEntry, setShowFullEntry] = useState(!!initialData);
```

This checks if `initialData` is provided (edit mode) and sets the initial state accordingly.

### User Experience Improvements
- **Edit Mode**: All fields visible immediately - no extra clicks needed
- **Create Mode**: Clean, simple form with optional fields hidden
- **Consistent Behavior**: Toggle button works the same in both modes
- **Better Workflow**: Reduces friction when editing existing activities

## Fixes
Fixes #12

## Test plan
- [x] Navigate to activity detail page and click "Edit Activity"
- [x] Verify additional details section is automatically expanded
- [x] Confirm all fields visible (distance, elevation, people, tags, weather, temperature)
- [x] Click "Add New Activity" (floating button)
- [x] Verify additional details section is collapsed by default
- [x] Test toggle button works in both edit and create modes
- [x] Build passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)