### PR TITLE
[v0.7.3] Add full-size image view modal

### DIFF
--- a/app/activities/[id]/page.tsx
+++ b/app/activities/[id]/page.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { getImageUrl } from '@/lib/garage';
 import { formatDetailDate } from '@/lib/dateUtils';
+import ImageModal from '@/components/ImageModal';
 
 export default function ActivityDetailPage({
   params,
@@ -21,6 +22,7 @@ export default function ActivityDetailPage({
   const [activity, setActivity] = useState<Activity | null>(null);
   const [loading, setLoading] = useState(true);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [showImageModal, setShowImageModal] = useState(false);
 
   useEffect(() => {
     const fetchActivity = async () => {
@@ -97,16 +99,24 @@ export default function ActivityDetailPage({
             <p className="text-warm-600">{formatDetailDate(activity.activity_date)}</p>
           </div>
 
-          {/* Activity Image (v0.4.0) */}
+          {/* Activity Image - v0.7.3 clickable for full-size view */}
           {activity.image_key && (
-            <div className="mb-6 relative w-full aspect-video bg-warm-100 rounded-card overflow-hidden">
+            <div
+              className="mb-6 relative w-full aspect-video bg-warm-100 rounded-card overflow-hidden cursor-pointer group"
+              onClick={() => setShowImageModal(true)}
+            >
               <Image
                 src={getImageUrl(activity.image_key) || ''}
                 alt={activity.title}
                 fill
-                className="object-cover"
+                className="object-cover group-hover:scale-105 transition-transform duration-300"
                 sizes="(max-width: 768px) 100vw, 768px"
               />
+              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300 flex items-center justify-center">
+                <span className="text-white text-5xl opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                  🔍
+                </span>
+              </div>
             </div>
           )}
 
@@ -209,6 +219,15 @@ export default function ActivityDetailPage({
           </div>
         </div>
       </div>
+
+      {/* Image Modal - v0.7.3 */}
+      {showImageModal && activity.image_key && (
+        <ImageModal
+          imageUrl={getImageUrl(activity.image_key) || ''}
+          alt={activity.title}
+          onClose={() => setShowImageModal(false)}
+        />
+      )}
     </main>
   );
 }

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Activity } from '@/types/activity';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { getImageUrl } from '@/lib/garage';
 import { formatActivityDate } from '@/lib/dateUtils';
+import ImageModal from './ImageModal';
 
 interface ActivityCardProps {
   activity: Activity;
@@ -14,6 +15,7 @@ interface ActivityCardProps {
 
 export default function ActivityCard({ activity }: ActivityCardProps) {
   const router = useRouter();
+  const [showImageModal, setShowImageModal] = useState(false);
 
   const formatDuration = (minutes: number) => {
     if (minutes < 60) {
@@ -49,20 +51,33 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
   };
 
   return (
-    <Link href={`/activities/${activity.id}`}>
-      <div className="bg-white rounded-card shadow-card hover:shadow-hover transition-all duration-300 border border-warm-200 hover-lift activity-card overflow-hidden cursor-pointer">
-        {/* Activity Image - unchanged */}
-        {activity.image_key && (
-          <div className="relative w-full aspect-video bg-warm-100">
-            <Image
-              src={getImageUrl(activity.image_key) || ''}
-              alt={activity.title}
-              fill
-              className="object-cover"
-              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-            />
-          </div>
-        )}
+    <>
+      <Link href={`/activities/${activity.id}`}>
+        <div className="bg-white rounded-card shadow-card hover:shadow-hover transition-all duration-300 border border-warm-200 hover-lift activity-card overflow-hidden cursor-pointer">
+          {/* Activity Image - v0.7.3 clickable for full-size view */}
+          {activity.image_key && (
+            <div
+              className="relative w-full aspect-video bg-warm-100 group"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setShowImageModal(true);
+              }}
+            >
+              <Image
+                src={getImageUrl(activity.image_key) || ''}
+                alt={activity.title}
+                fill
+                className="object-cover group-hover:scale-105 transition-transform duration-300"
+                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              />
+              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300 flex items-center justify-center">
+                <span className="text-white text-4xl opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                  🔍
+                </span>
+              </div>
+            </div>
+          )}
 
         <div className="p-4">
           {/* Header: Title and Badges */}
@@ -129,5 +144,15 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
         </div>
       </div>
     </Link>
+
+      {/* Image Modal - v0.7.3 */}
+      {showImageModal && activity.image_key && (
+        <ImageModal
+          imageUrl={getImageUrl(activity.image_key) || ''}
+          alt={activity.title}
+          onClose={() => setShowImageModal(false)}
+        />
+      )}
+    </>
   );
 }

--- a/components/ImageModal.tsx
+++ b/components/ImageModal.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import Image from 'next/image';
+
+interface ImageModalProps {
+  imageUrl: string;
+  alt: string;
+  onClose: () => void;
+}
+
+export default function ImageModal({ imageUrl, alt, onClose }: ImageModalProps) {
+  useEffect(() => {
+    // Close on ESC key
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    // Prevent body scroll when modal is open
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.body.style.overflow = 'unset';
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm animate-fadeIn p-4"
+      onClick={onClose}
+    >
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 w-12 h-12 flex items-center justify-center bg-white/10 hover:bg-white/20 rounded-full text-white text-2xl font-bold transition-colors z-[101]"
+        aria-label="Close image"
+      >
+        ×
+      </button>
+
+      <div
+        className="relative max-w-[90vw] max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+        style={{ aspectRatio: 'auto' }}
+      >
+        <Image
+          src={imageUrl}
+          alt={alt}
+          width={1920}
+          height={1080}
+          className="object-contain max-w-full max-h-[90vh] w-auto h-auto"
+          sizes="90vw"
+          priority
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add the ability to view activity images in full-size modal by clicking on them from both the feed cards and activity detail pages.

### Features Added
- **ImageModal Component** - Reusable modal for full-size image viewing
  - Dark overlay with backdrop blur
  - Click outside to close
  - ESC key to close
  - Close button (×) in top right
  - Prevents body scroll when open
  - Smooth fade-in animation

- **Clickable Feed Card Images**
  - Hover effects with zoom icon (🔍)
  - Image scales up slightly on hover
  - Dark overlay on hover
  - Stops propagation to prevent navigation
  - Opens full-size modal

- **Clickable Detail Page Images**
  - Larger images with same hover effects
  - Zoom icon appears on hover
  - Opens full-size modal

### User Experience Improvements
- Visual feedback with zoom icon and scale effect
- Smooth transitions for all interactions
- Keyboard accessible (ESC to close)
- Mobile-friendly touch targets
- Images centered and contained within viewport

### Design Features
- Warm color integration
- Smooth hover transitions
- Professional modal presentation
- Responsive sizing (max 90vw/90vh)

## Fixes
Fixes #15

## Test plan
- [x] Navigate to main feed
- [x] Hover over activity images - zoom icon appears
- [x] Click on feed card image - modal opens
- [x] Click outside image to close modal
- [x] Test ESC key to close modal
- [x] Test close button (×)
- [x] Navigate to activity detail page
- [x] Click detail page image - modal opens
- [x] Test on mobile - touch interactions work
- [x] Build passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)