### PR TITLE
v0.7.4 - Modernize Banner

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -60,14 +60,19 @@ export default function DashboardPage() {
   return (
     <main className="min-h-screen bg-warm-50 page-enter">
       <div className="max-w-7xl mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="bg-gradient-to-br from-cream via-warm-50 to-sand py-12 mb-8 -mx-4 px-4">
-          <h1 className="text-4xl font-bold text-warm-900 mb-2">Little Roamers</h1>
-          <p className="text-warm-600 text-lg">Growing Up Outdoors</p>
+        {/* Header - v0.7.4 modernized */}
+        <div className="bg-gradient-to-b from-[#FBF7F0] via-[#F4EAD5] to-[#E8F4E8] pt-16 pb-10 mb-8 -mx-4 px-4 text-center sm:text-left shadow-[0_8px_16px_-4px_rgba(0,0,0,0.06)] relative">
+          <h1 className="text-5xl font-extrabold text-warm-900 mb-3 tracking-tight">
+            Little Roamers
+          </h1>
+          <p className="text-warm-600/70 text-base mb-4">Growing Up Outdoors</p>
           {stats.hoursThisYear !== null && stats.hoursThisYear > 0 && (
-            <p className="text-sage-dark font-semibold text-lg mt-2">
-              🌳 {stats.hoursThisYear} hours outside this year
-            </p>
+            <div className="inline-flex items-center gap-2 bg-white/60 backdrop-blur-sm px-4 py-2 rounded-full border border-sage/30 shadow-sm">
+              <span className="text-sm text-warm-800">
+                <span className="text-xl font-bold text-sage-dark">{stats.hoursThisYear}</span>
+                <span className="text-xl font-bold text-warm-800"> / 1026</span> hrs Outside
+              </span>
+            </div>
           )}
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,7 @@ function HomeContent() {
   } = useActivities();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [hoursThisYear, setHoursThisYear] = useState<number | null>(null);
+  const [totalHours, setTotalHours] = useState<number | null>(null);
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -34,6 +35,7 @@ function HomeContent() {
         if (response.ok) {
           const data = await response.json();
           setHoursThisYear(data.stats.hoursThisYear);
+          setTotalHours(data.stats.totalHours);
         }
       } catch (err) {
         console.error('Error fetching hours this year:', err);
@@ -88,14 +90,19 @@ function HomeContent() {
   return (
     <main className="min-h-screen bg-warm-50 page-enter">
       <div className="max-w-7xl mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="bg-gradient-to-br from-cream via-warm-50 to-sand py-12 mb-8 -mx-4 px-4">
-          <h1 className="text-4xl font-bold text-warm-900 mb-2">Little Roamers</h1>
-          <p className="text-warm-600 text-lg">Growing Up Outdoors</p>
+        {/* Header - v0.7.4 modernized */}
+        <div className="bg-gradient-to-b from-[#FBF7F0] via-[#F4EAD5] to-[#E8F4E8] pt-16 pb-10 mb-8 -mx-4 px-4 text-center sm:text-left shadow-[0_8px_16px_-4px_rgba(0,0,0,0.06)] relative">
+          <h1 className="text-5xl font-extrabold text-warm-900 mb-3 tracking-tight">
+            Little Roamers
+          </h1>
+          <p className="text-warm-600/70 text-base mb-4">Growing Up Outdoors</p>
           {hoursThisYear !== null && hoursThisYear > 0 && (
-            <p className="text-sage-dark font-semibold text-lg mt-2">
-              🌳 {hoursThisYear} hours outside this year
-            </p>
+            <div className="inline-flex items-center gap-2 bg-white/60 backdrop-blur-sm px-4 py-2 rounded-full border border-sage/30 shadow-sm">
+              <span className="text-sm text-warm-800">
+                <span className="text-xl font-bold text-sage-dark">{hoursThisYear}</span>
+                <span className="text-xl font-bold text-warm-800"> / 1026</span> hrs Outside
+              </span>
+            </div>
           )}
         </div>
 

--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -15,14 +15,14 @@ export default function NavigationBar() {
   };
 
   return (
-    <nav className="bg-white rounded-card shadow-card border border-warm-200 p-2 mb-6">
-      <div className="flex gap-2">
+    <nav className="bg-white rounded-card shadow-card border border-warm-200 p-1.5 mb-6">
+      <div className="flex gap-1.5">
         <Link href="/" className="flex-1">
           <button
-            className={`w-full px-4 py-2.5 rounded-xl font-semibold transition-all duration-200 ${
+            className={`w-full px-4 py-2 rounded-xl font-semibold transition-all duration-200 ${
               isActive('/')
-                ? 'bg-sage text-white shadow-soft'
-                : 'bg-transparent text-warm-700 hover:bg-warm-100'
+                ? 'bg-sage text-white shadow-[0_4px_10px_rgba(0,0,0,0.08)]'
+                : 'bg-transparent text-warm-700 opacity-70 hover:opacity-100 hover:bg-warm-50'
             }`}
           >
             🏠 Feed
@@ -30,10 +30,10 @@ export default function NavigationBar() {
         </Link>
         <Link href="/dashboard" className="flex-1">
           <button
-            className={`w-full px-4 py-2.5 rounded-xl font-semibold transition-all duration-200 ${
+            className={`w-full px-4 py-2 rounded-xl font-semibold transition-all duration-200 ${
               isActive('/dashboard')
-                ? 'bg-sage text-white shadow-soft'
-                : 'bg-transparent text-warm-700 hover:bg-warm-100'
+                ? 'bg-sage text-white shadow-[0_4px_10px_rgba(0,0,0,0.08)]'
+                : 'bg-transparent text-warm-700 opacity-70 hover:opacity-100 hover:bg-warm-50'
             }`}
           >
             📊 Dashboard


### PR DESCRIPTION
## Summary
- Modernized banner with stronger visual hierarchy and prominent warm-to-green gradient
- Transformed hours stat into frosted glass pill card with "X.X / 1026 hrs Outside" format
- Refined navigation bar with enhanced active states and smoother transitions
- Added mobile-first centering with responsive alignment

## Visual Changes
- **Banner Title**: Increased to text-5xl with extrabold weight and tighter tracking
- **Subtitle**: Lighter opacity (text-warm-600/70) for better hierarchy
- **Gradient**: Custom warm-to-green gradient (cream → sand → pale sage) with subtle shadow
- **Hours Pill**: Frosted glass background with backdrop blur, larger bold numbers, border accent
- **Navigation**: Reduced padding, enhanced active shadow, opacity-based hover states

## Test Plan
- [x] Verify banner gradient is visible and prominent
- [x] Confirm pill displays "X.X / 1026 hrs Outside" with proper formatting
- [x] Check mobile centering and desktop left-alignment
- [x] Test navigation tab states (active vs inactive)
- [x] Verify consistent styling on both Feed and Dashboard pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)