### PR TITLE
v0.8.0: Complete Docker deployment with README updates and env fix

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -69,7 +69,7 @@ chmod +x scripts/init-garage.sh
 # Copy credentials from output to .env.docker
 
 # 3. Start stack
-docker compose up -d
+docker compose --env-file .env.docker up -d
 
 # 4. Verify health
 docker compose ps
@@ -78,6 +78,8 @@ docker compose ps
 # 5. Access application
 open http://localhost:3000
 ```
+
+**Note**: The `--env-file .env.docker` flag tells Docker Compose to read environment variables from `.env.docker` instead of the default `.env` file.
 
 ---
 
@@ -345,15 +347,15 @@ docker compose exec app ./run-migrations.sh
 Start all services in detached mode:
 
 ```bash
-docker compose up -d
+docker compose --env-file .env.docker up -d
 ```
 
 Start specific service:
 
 ```bash
-docker compose up -d postgres
-docker compose up -d garage
-docker compose up -d app
+docker compose --env-file .env.docker up -d postgres
+docker compose --env-file .env.docker up -d garage
+docker compose --env-file .env.docker up -d app
 ```
 
 ### Stopping Services

--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@ cp .env.docker.example .env.docker
 # Copy credentials to .env.docker
 
 # 3. Start the stack
-docker compose up -d
+docker compose --env-file .env.docker up -d
 
 # 4. Verify health
 docker compose ps
 ./scripts/health-check.sh
 ```
+
+> **Note**: The `--env-file .env.docker` flag is required to load environment variables from `.env.docker`.
 
 Open [http://localhost:3000](http://localhost:3000) to view the app.
 

--- a/scripts/init-garage.sh
+++ b/scripts/init-garage.sh
@@ -7,6 +7,18 @@ echo "Little Roamers v0.8.0"
 echo "======================================"
 echo ""
 
+# Check if .env.docker exists
+if [ ! -f ".env.docker" ]; then
+  echo "❌ Error: .env.docker file not found!"
+  echo "Please create .env.docker from .env.docker.example first:"
+  echo "  cp .env.docker.example .env.docker"
+  echo "  # Then edit .env.docker and set POSTGRES_PASSWORD"
+  exit 1
+fi
+
+echo "✅ Found .env.docker"
+echo ""
+
 # Step 1: Generate RPC secret and create garage.toml
 echo "Step 1: Generating garage.toml configuration..."
 if [ -f "garage.toml" ]; then
@@ -39,7 +51,7 @@ fi
 
 echo ""
 echo "Step 2: Starting Garage container..."
-docker compose up -d garage
+docker compose --env-file .env.docker up -d garage
 echo "⏳ Waiting 10 seconds for Garage to initialize..."
 sleep 10
 


### PR DESCRIPTION
## Summary
Complete the v0.8.0 Docker deployment by merging the remaining commits that were added after PR #24:

- Update README.md to reflect v0.8.0 Docker deployment as the primary setup method
- Fix environment variable loading in Docker Compose (add `--env-file .env.docker` flag)
- Update DEPLOY.md with proper env file flag usage

## Changes
- `899de61`: Update README for v0.8.0 Docker deployment
- `fd9e2c2`: Fix environment variable loading for Docker Compose

## Testing
- ✅ All docker compose commands now use `--env-file .env.docker` flag
- ✅ README reflects current v0.8.0 state
- ✅ Documentation is consistent across README and DEPLOY.md

Related to #9 (v0.8.0 Docker Deployment)