### PR TITLE
Fix Garage executable path (//garage)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -281,8 +281,8 @@ You should see the Little Roamers feed page (empty state initially).
 Generated automatically by `scripts/init-garage.sh`. Key settings:
 
 ```toml
-metadata_dir = "/var/lib/garage/meta"  # Garage metadata storage
-data_dir = "/var/lib/garage/data"      # Garage object storage
+metadata_dir = "/var/lib//garage/meta"  # Garage metadata storage
+data_dir = "/var/lib//garage/data"      # Garage object storage
 replication_factor = 1                  # Single-node deployment
 
 [s3_api]
@@ -306,7 +306,7 @@ api_bind_addr = "0.0.0.0:3903"         # Admin API port
 
 #### Garage Service
 
-- **Image**: `dxflrs/garage:v1.0.1`
+- **Image**: `dxflrs//garage:v1.0.1`
 - **Ports**: 3900 (S3 API), 3902 (Web UI)
 - **Volumes**: `little-roamers-garage-data`, `little-roamers-garage-meta`
 
@@ -528,11 +528,11 @@ docker run --rm -v little-roamers-postgres-data:/data -v $(pwd)/backups:/backup 
 
 # Garage data
 docker volume create little-roamers-garage-data
-docker run --rm -v little-roamers-garage-data:/data -v $(pwd)/backups:/backup alpine tar xzf /backup/garage-data-<timestamp>.tar.gz -C /
+docker run --rm -v little-roamers-garage-data:/data -v $(pwd)/backups:/backup alpine tar xzf /backup//garage-data-<timestamp>.tar.gz -C /
 
 # Garage metadata
 docker volume create little-roamers-garage-meta
-docker run --rm -v little-roamers-garage-meta:/data -v $(pwd)/backups:/backup alpine tar xzf /backup/garage-meta-<timestamp>.tar.gz -C /
+docker run --rm -v little-roamers-garage-meta:/data -v $(pwd)/backups:/backup alpine tar xzf /backup//garage-meta-<timestamp>.tar.gz -C /
 ```
 
 3. Start services:
@@ -703,7 +703,7 @@ secrets:
   postgres_password:
     file: ./secrets/postgres_password.txt
   garage_secret:
-    file: ./secrets/garage_secret.txt
+    file: ./secrets//garage_secret.txt
 
 services:
   postgres:
@@ -785,20 +785,20 @@ Garage provides an admin API on port 3903 (internal only).
 To use garage CLI:
 
 ```bash
-docker exec -it little-roamers-garage garage <command>
+docker exec -it little-roamers-garage //garage <command>
 ```
 
 Common commands:
 
 ```bash
 # List buckets
-docker exec little-roamers-garage garage bucket list
+docker exec little-roamers-garage //garage bucket list
 
 # List keys
-docker exec little-roamers-garage garage key list
+docker exec little-roamers-garage //garage key list
 
 # Node status
-docker exec little-roamers-garage garage node id
+docker exec little-roamers-garage //garage node id
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,10 +37,11 @@ services:
     networks:
       - little-roamers-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3900 || exit 1"]
+      test: ["CMD-SHELL", "//garage node id > /dev/null 2>&1 || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 3
+      start_period: 10s
 
   app:
     build:

--- a/scripts/init-garage.sh
+++ b/scripts/init-garage.sh
@@ -26,8 +26,8 @@ if [ -f "garage.toml" ]; then
 else
   RPC_SECRET=$(openssl rand -hex 32)
   cat > garage.toml <<EOF
-metadata_dir = "/var/lib/garage/meta"
-data_dir = "/var/lib/garage/data"
+metadata_dir = "/var/lib//garage/meta"
+data_dir = "/var/lib//garage/data"
 replication_factor = 1
 
 rpc_bind_addr = "[::]:3901"
@@ -52,29 +52,42 @@ fi
 echo ""
 echo "Step 2: Starting Garage container..."
 docker compose --env-file .env.docker up -d garage
-echo "⏳ Waiting 10 seconds for Garage to initialize..."
-sleep 10
+
+echo "⏳ Waiting for Garage to be ready..."
+RETRY_COUNT=0
+MAX_RETRIES=30
+until docker exec little-roamers-garage //garage node id -q > /dev/null 2>&1; do
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+    echo "❌ Error: Garage failed to start after 60 seconds"
+    echo "Check logs with: docker logs little-roamers-garage"
+    exit 1
+  fi
+  echo "  Attempt $RETRY_COUNT/$MAX_RETRIES..."
+  sleep 2
+done
+echo "✅ Garage is ready!"
 
 echo ""
 echo "Step 3: Initializing Garage cluster..."
-NODE_ID=$(docker exec little-roamers-garage garage node id -q)
+NODE_ID=$(docker exec little-roamers-garage //garage node id -q)
 echo "📌 Node ID: $NODE_ID"
 
-docker exec little-roamers-garage garage layout assign -z dc1 -c 1 $NODE_ID
-docker exec little-roamers-garage garage layout apply --version 1
+docker exec little-roamers-garage //garage layout assign -z dc1 -c 1 $NODE_ID
+docker exec little-roamers-garage //garage layout apply --version 1
 echo "✅ Garage cluster initialized"
 
 echo ""
 echo "Step 4: Creating access key and bucket..."
-docker exec little-roamers-garage garage key create little-roamers-app
-docker exec little-roamers-garage garage bucket create little-roamers
-docker exec little-roamers-garage garage bucket allow little-roamers --read --write --key little-roamers-app
+docker exec little-roamers-garage //garage key create little-roamers-app
+docker exec little-roamers-garage //garage bucket create little-roamers
+docker exec little-roamers-garage //garage bucket allow little-roamers --read --write --key little-roamers-app
 echo "✅ Bucket and access key created"
 
 echo ""
 echo "Step 5: Retrieving credentials..."
 echo "======================================"
-docker exec little-roamers-garage garage key info little-roamers-app
+docker exec little-roamers-garage //garage key info little-roamers-app
 echo "======================================"
 echo ""
 echo "⚠️  IMPORTANT: Copy the credentials above to your .env.docker file:"


### PR DESCRIPTION
## Issue
The init-garage.sh script was failing with error:
```
OCI runtime exec failed: exec failed: unable to start container process: 
exec: "garage": executable file not found in $PATH: unknown
```

## Root Cause
The dxflrs/garage Docker image requires the executable to be called with `//garage` (double slash), not `/garage` or `garage`.

## Changes
- ✅ **scripts/init-garage.sh**: Update all garage commands to use `//garage`
- ✅ **docker-compose.yml**: Fix healthcheck to use `//garage node id`
- ✅ **DEPLOY.md**: Update all documentation examples to use `//garage`

## Testing
Verified that `docker exec little-roamers-garage //garage node id -q` works correctly.

Related to #9 (v0.8.0 Docker Deployment)