### PR TITLE
Fix Garage initialization and Docker build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,13 @@ COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
+# Dummy env vars for build time (overridden at runtime)
+ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
+ENV GARAGE_ENDPOINT="http://localhost:3900"
+ENV GARAGE_REGION="garage"
+ENV GARAGE_ACCESS_KEY_ID="dummy"
+ENV GARAGE_SECRET_ACCESS_KEY="dummy"
+ENV GARAGE_BUCKET="dummy"
 RUN npm run build
 
 # Stage 3: Runner

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ cp .env.docker.example .env.docker
 docker compose --env-file .env.docker up -d
 
 # 4. Verify health
-docker compose ps
+docker compose --env-file .env.docker ps
 ./scripts/health-check.sh
 ```
 
-> **Note**: The `--env-file .env.docker` flag is required to load environment variables from `.env.docker`.
+> **IMPORTANT**: Always use `--env-file .env.docker` with ALL `docker compose` commands to load environment variables from `.env.docker`.
 
 Open [http://localhost:3000](http://localhost:3000) to view the app.
 

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -2,7 +2,7 @@
 
 echo "Little Roamers Health Status"
 echo "======================================"
-docker compose ps
+docker compose --env-file .env.docker ps
 echo ""
 echo "Detailed Health Checks:"
 echo "----------------------"

--- a/scripts/init-garage.sh
+++ b/scripts/init-garage.sh
@@ -70,8 +70,10 @@ echo "✅ Garage is ready!"
 
 echo ""
 echo "Step 3: Initializing Garage cluster..."
-NODE_ID=$(docker exec little-roamers-garage //garage node id -q)
-echo "📌 Node ID: $NODE_ID"
+NODE_ID_FULL=$(docker exec little-roamers-garage //garage node id -q)
+NODE_ID=$(echo "$NODE_ID_FULL" | cut -d'@' -f1)
+echo "📌 Node ID: $NODE_ID_FULL"
+echo "📌 Using Node ID (without address): $NODE_ID"
 
 docker exec little-roamers-garage //garage layout assign -z dc1 -c 1 $NODE_ID
 docker exec little-roamers-garage //garage layout apply --version 1

--- a/scripts/init-garage.sh
+++ b/scripts/init-garage.sh
@@ -75,7 +75,7 @@ NODE_ID=$(echo "$NODE_ID_FULL" | cut -d'@' -f1)
 echo "📌 Node ID: $NODE_ID_FULL"
 echo "📌 Using Node ID (without address): $NODE_ID"
 
-docker exec little-roamers-garage //garage layout assign -z dc1 -c 1 $NODE_ID
+docker exec little-roamers-garage //garage layout assign -z dc1 -c 1G $NODE_ID
 docker exec little-roamers-garage //garage layout apply --version 1
 echo "✅ Garage cluster initialized"
 


### PR DESCRIPTION
## Summary
Additional fixes discovered during Docker deployment testing:

## Issues Fixed

### 1. Garage Node ID Extraction
- **Issue**: `layout assign` command failed with "0 nodes match" error
- **Fix**: Strip `@127.0.0.1:3901` address portion from node ID
- **Commit**: `92eb1aa`

### 2. Garage Cluster Capacity
- **Issue**: "storage capacity of the cluster is too small" error
- **Fix**: Changed capacity from `-c 1` to `-c 1G` (1 gigabyte)
- **Commit**: `1325805`

### 3. Docker Build Environment Variables
- **Issue**: Next.js build failed with "Missing DATABASE_URL environment variable"
- **Fix**: Added dummy env vars for build stage (overridden at runtime)
- **Commit**: `5c01796`

### 4. Documentation Clarity
- **Issue**: Users were running `docker compose` without `--env-file` flag
- **Fix**: Emphasized IMPORTANT use of `--env-file .env.docker` in all commands
- **Commit**: `20251af`

## Testing
All fixes have been tested during actual Docker deployment:
- ✅ Garage initializes successfully
- ✅ Docker build completes without errors
- ✅ Documentation clearly indicates required flags

Related to #9 (v0.8.0 Docker Deployment)
Follow-up to PR #26