### PR TITLE
Fix Docker build error with empty public directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,11 @@ RUN apk add --no-cache postgresql-client
 
 RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001
 
+# Create public directory
+RUN mkdir -p ./public
+
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
 # Copy schema and migration script
 COPY --chown=nextjs:nodejs schema.sql ./schema.sql


### PR DESCRIPTION
## Issue
Docker build was failing with error:
```
failed to compute cache key: failed to calculate checksum of ref: 
"/app/public": not found
```

## Root Cause
The `public` directory exists but is empty (no files). Docker's COPY command fails when trying to copy from an empty directory in multi-stage builds.

## Fix
- Removed the `COPY /app/public ./public` line
- Instead, create an empty `public` directory with `mkdir -p`
- This allows the build to complete successfully
- If files are added to `public/` in the future, we can add the COPY command back

## Testing
Verified Docker build now completes without errors.

Related to #9 (v0.8.0 Docker Deployment)
Follow-up to PR #27

**Commit**: `ba00399`