### PR TITLE
Remove Garage healthcheck due to missing shell

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,6 @@ services:
       - "3902:3902"
     networks:
       - little-roamers-network
-    healthcheck:
-      test: ["CMD-SHELL", "//garage node id > /dev/null 2>&1 || exit 1"]
-      interval: 15s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
 
   app:
     build:
@@ -71,7 +65,7 @@ services:
       postgres:
         condition: service_healthy
       garage:
-        condition: service_healthy
+        condition: service_started
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/activities || exit 1"]
       interval: 30s


### PR DESCRIPTION
## Issue
The garage service was showing as "unhealthy" with 242 consecutive failed healthchecks, despite the container running correctly.

## Root Cause  
The `dxflrs/garage:v1.0.1` image is minimal and doesn't include `/bin/sh`, causing all healthchecks using `CMD-SHELL` format to fail with:
```
stat /bin/sh: no such file or directory
```

## Fix
- ✅ Removed healthcheck from garage service entirely
- ✅ Changed app dependency on garage from `condition: service_healthy` to `condition: service_started`

The garage container runs perfectly; it just can't execute shell-based healthchecks. The app will now wait for garage to start but not for a healthcheck to pass.

## Testing
After this change:
- Garage service will no longer show as "unhealthy"
- App will start after garage container starts
- All functionality works as expected

Related to #9 (v0.8.0 Docker Deployment)

**Commit**: `4742f88`